### PR TITLE
[#35] Agent eval harness 骨架（ADR-003 决策 1-13）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ dist/
 build/
 node_modules/
 eco-prof-app/
+
+# evals harness（ADR-003 决策 15）
+evals/fixtures/*.db
+evals/results/
+.opencode/agent/eval-*.md

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,93 @@
+# Agent Eval Harness
+
+基于 ADR-003 的 agent 端到端测试框架。
+
+**架构文档：** `docs/adr/003-agent-eval-harness.md`
+
+---
+
+## 快速开始
+
+### 1. 配置 DeepSeek API Key
+
+```bash
+export DEEPSEEK_API_KEY=sk-...
+```
+
+Key 仅通过环境变量读取，不写入磁盘。
+（`evals/config.yaml` 只存 `api_key_env` 字段名，不含密钥）
+
+### 2. 运行 Smoke Test
+
+```bash
+# 验证 harness 骨架可跑通（无需数据库）
+python -m evals.harness.run --scenario evals/smoke/scenarios/hello.md
+```
+
+预期产出：
+```
+evals/results/<timestamp>/smoke_hello/
+  conversation.md   # 人类可读对话
+  events.jsonl      # opencode 原始事件流
+  scores.json       # judge 打分
+  report.md         # rubric + 打分 + Human review checkbox
+```
+
+### 3. 运行 Micro Skill Eval（需先准备 fixture）
+
+```bash
+# Step 1：生成 fixture（需真实网络数据）
+python -m evals.harness.seed_fixtures
+
+# Step 2：运行三市场 scenario
+python -m evals.harness.run --scenario evals/micro/scenarios/basic_cn.md
+python -m evals.harness.run --scenario evals/micro/scenarios/basic_hk.md
+python -m evals.harness.run --scenario evals/micro/scenarios/basic_us.md
+```
+
+---
+
+## 目录结构
+
+```
+evals/
+  README.md               # 本文件
+  config.yaml             # judge provider 配置（无密钥）
+  benchmark-log.md        # 跨 run 趋势表
+  harness/
+    run.py                # 入口（python -m evals.harness.run）
+    judge.py              # LLM judge（DeepSeek）
+    parser.py             # scenario / rubric 解析
+    agent_builder.py      # 动态生成 opencode agent
+    seed_fixtures.py      # fixture 种子脚本
+    config.py             # 读取 config.yaml
+  smoke/
+    scenarios/hello.md    # Smoke scenario（自测 harness）
+    rubrics/hello.md      # Smoke rubric
+  micro/
+    scenarios/            # A股 / 港股 / 美股 scenario
+    rubrics/adr-002.md    # ADR-002 的 16 条决策 → rubric
+  fixtures/               # gitignored，seed 脚本生成
+  results/                # gitignored，每次 run 产出
+```
+
+---
+
+## Gitignore 策略
+
+**commit（进 git）：**
+- `harness/**/*.py`、scenario / rubric `.md`、`config.yaml`、`benchmark-log.md`
+
+**gitignore：**
+- `fixtures/*.db`（seed 脚本重新生成）
+- `results/`（本地保留，不污染仓库）
+- `.opencode/agent/eval-*.md`（harness 动态生成的临时 agent）
+
+---
+
+## 测试分层（ADR-003 决策 1）
+
+| Layer | 方式 | 频率 |
+|-------|------|------|
+| L2 | LLM judge 自动打分（本 harness）| 每次 skill/persona 变更后 |
+| L4 | 人工在 report.md 上勾 checkbox | Sprint review |

--- a/evals/benchmark-log.md
+++ b/evals/benchmark-log.md
@@ -1,0 +1,6 @@
+# Benchmark Log
+
+跨 run 追踪 agent eval 结果趋势（ADR-003 决策 14）。
+
+| 日期 | git sha | scenarios pass | judge avg | human agree rate | 备注 |
+|------|---------|---------------|-----------|-----------------|------|

--- a/evals/config.yaml
+++ b/evals/config.yaml
@@ -1,0 +1,7 @@
+judge:
+  provider: deepseek
+  model: deepseek-chat
+  base_url: https://api.deepseek.com/v1
+  api_key_env: DEEPSEEK_API_KEY
+  temperature: 0.0
+  timeout_seconds: 60

--- a/evals/harness/__init__.py
+++ b/evals/harness/__init__.py
@@ -1,0 +1,1 @@
+# evals.harness — Agent eval harness (ADR-003)

--- a/evals/harness/agent_builder.py
+++ b/evals/harness/agent_builder.py
@@ -1,0 +1,59 @@
+"""
+harness/agent_builder.py — 动态生成 opencode agent 文件（ADR-003 决策 10）
+
+流程：
+  1. 读 persona 文件（src/eco-prof.md）
+  2. 读 skills 列表的每个 SKILL.md
+  3. 拼接 opencode agent 格式（frontmatter + 正文）
+  4. 写入 .opencode/agent/eval-<scenario_id>.md
+  5. 返回临时 agent 名字供 run.py 调用
+
+cleanup(scenario_id) 删除临时文件。
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from .parser import Scenario
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+_AGENT_DIR = _REPO_ROOT / ".opencode" / "agent"
+
+
+def build(scenario: Scenario) -> str:
+    """生成临时 agent 文件，返回 agent 名字（不含 .md 后缀）。"""
+    agent_name = f"eval-{scenario.scenario_id}"
+    agent_path = _AGENT_DIR / f"{agent_name}.md"
+    _AGENT_DIR.mkdir(parents=True, exist_ok=True)
+
+    parts: list[str] = []
+
+    # ── 读 persona ──
+    persona_path = _REPO_ROOT / scenario.persona
+    if persona_path.exists():
+        persona_text = persona_path.read_text(encoding="utf-8").strip()
+        parts.append(persona_text)
+    else:
+        parts.append(f"# Persona: {scenario.persona}\n(file not found)")
+
+    # ── 读 skills ──
+    for skill_rel in scenario.skills:
+        skill_path = _REPO_ROOT / skill_rel
+        if skill_path.exists():
+            skill_text = skill_path.read_text(encoding="utf-8").strip()
+            parts.append(f"\n\n---\n\n{skill_text}")
+        else:
+            parts.append(f"\n\n# Skill: {skill_rel}\n(file not found)")
+
+    agent_content = "\n\n".join(parts)
+    agent_path.write_text(agent_content, encoding="utf-8")
+    return agent_name
+
+
+def cleanup(scenario_id: str) -> None:
+    """删除临时 agent 文件。"""
+    agent_path = _AGENT_DIR / f"eval-{scenario_id}.md"
+    if agent_path.exists():
+        agent_path.unlink()

--- a/evals/harness/config.py
+++ b/evals/harness/config.py
@@ -1,0 +1,27 @@
+"""
+harness/config.py — 读取 evals/config.yaml（ADR-003 决策 13）
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+_CONFIG_PATH = Path(__file__).parent.parent / "config.yaml"
+
+
+def load_config() -> Dict[str, Any]:
+    """加载 evals/config.yaml，返回配置字典。"""
+    with open(_CONFIG_PATH, encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def judge_config() -> Dict[str, Any]:
+    """返回 judge 配置块，并解析 api_key_env → api_key。"""
+    cfg = load_config().get("judge", {})
+    api_key_env = cfg.get("api_key_env", "DEEPSEEK_API_KEY")
+    cfg["api_key"] = os.environ.get(api_key_env, "")
+    return cfg

--- a/evals/harness/judge.py
+++ b/evals/harness/judge.py
@@ -1,0 +1,131 @@
+"""
+harness/judge.py — LLM judge（ADR-003 决策 12、13）
+
+One-shot prompt：把完整 rubric + 完整对话送给 judge，
+要求返回 JSON：{<rubric_id>: {"pass": bool, "reason": str, "quote": str}}
+
+若 judge 漏答某条 rubric item，per-item 补评。
+使用 openai SDK（openai-compatible endpoint）调 DeepSeek。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List
+
+from .config import judge_config
+from .parser import Rubric
+
+
+def _build_prompt(conversation: str, rubric: Rubric) -> str:
+    rubric_lines = "\n".join(
+        f"- id: {item.id}\n  question: {item.question}" for item in rubric.items
+    )
+    return f"""你是一个严格的 agent 行为评审员。
+请根据以下 rubric 评审 agent 对话，逐条判断每个 rubric item 是否通过。
+
+## Rubric
+{rubric_lines}
+
+## 对话内容
+{conversation}
+
+## 输出要求
+请返回严格的 JSON，格式如下（不要输出任何其他内容）：
+{{
+  "<rubric_item_id>": {{
+    "pass": true 或 false,
+    "reason": "简短中文理由",
+    "quote": "对话中的相关原文片段（≤100字）"
+  }}
+}}
+
+每条 rubric item 都必须有对应的答案。"""
+
+
+def _parse_json_response(text: str) -> Dict[str, Any]:
+    """从 LLM 回复中提取 JSON 对象。"""
+    # 去掉 markdown code fence
+    text = re.sub(r"```(?:json)?\s*", "", text).strip().rstrip("`").strip()
+    return json.loads(text)
+
+
+def score(conversation: str, rubric: Rubric) -> Dict[str, Any]:
+    """
+    调用 judge LLM 对对话打分。
+
+    返回：{rubric_item_id: {"pass": bool, "reason": str, "quote": str}}
+    若 DEEPSEEK_API_KEY 未设置，返回 {"_skipped": True}。
+    """
+    cfg = judge_config()
+    api_key = cfg.get("api_key", "")
+    if not api_key:
+        return {"_skipped": True, "_reason": "DEEPSEEK_API_KEY not set"}
+
+    try:
+        from openai import OpenAI
+    except ImportError:
+        return {"_skipped": True, "_reason": "openai package not installed"}
+
+    client = OpenAI(
+        api_key=api_key,
+        base_url=cfg.get("base_url", "https://api.deepseek.com/v1"),
+        timeout=cfg.get("timeout_seconds", 60),
+    )
+
+    prompt = _build_prompt(conversation, rubric)
+    response = client.chat.completions.create(
+        model=cfg.get("model", "deepseek-chat"),
+        messages=[{"role": "user", "content": prompt}],
+        temperature=cfg.get("temperature", 0.0),
+    )
+    raw = response.choices[0].message.content or ""
+
+    try:
+        scores = _parse_json_response(raw)
+    except json.JSONDecodeError:
+        scores = {"_parse_error": True, "_raw": raw}
+        return scores
+
+    # ── schema 校验：补评漏答的 item ──
+    missing = [item for item in rubric.items if item.id not in scores]
+    if missing:
+        scores = _fill_missing(client, cfg, conversation, missing, scores)
+
+    return scores
+
+
+def _fill_missing(
+    client: Any,
+    cfg: Dict[str, Any],
+    conversation: str,
+    missing: List[Any],
+    existing: Dict[str, Any],
+) -> Dict[str, Any]:
+    """对漏答的 rubric item 逐条补评。"""
+    for item in missing:
+        prompt = f"""请评审以下对话，判断单条 rubric item 是否通过：
+
+- id: {item.id}
+  question: {item.question}
+
+## 对话内容
+{conversation}
+
+## 输出要求
+返回严格 JSON（不含其他内容）：
+{{"{item.id}": {{"pass": true/false, "reason": "中文理由", "quote": "原文片段"}}}}"""
+
+        resp = client.chat.completions.create(
+            model=cfg.get("model", "deepseek-chat"),
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.0,
+        )
+        raw = resp.choices[0].message.content or ""
+        try:
+            part = _parse_json_response(raw)
+            existing.update(part)
+        except json.JSONDecodeError:
+            existing[item.id] = {"pass": False, "reason": "补评解析失败", "quote": ""}
+    return existing

--- a/evals/harness/parser.py
+++ b/evals/harness/parser.py
@@ -1,0 +1,124 @@
+"""
+harness/parser.py — Scenario & Rubric Markdown 解析（ADR-003 决策 5、11）
+
+Scenario 文件格式：
+  ---
+  scenario_id: micro_basic_cn
+  mode: offline           # offline | live
+  persona: src/eco-prof.md
+  skills:
+    - src/skills/micro/SKILL.md
+  fixture: micro_seeded   # offline 模式需要
+  rubric: evals/micro/rubrics/adr-002.md
+  tags: [micro, cn, happy-path]
+  ---
+
+  ## Input
+  帮我估值 000725.SZ
+
+  ## Notes
+  验证 ADR-002 的 16 个决策……
+
+Rubric 文件格式：
+  ---
+  rubric_id: smoke_hello
+  ---
+  # Rubric Title
+  - id: item_id
+    question: 评估问题？
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+
+
+@dataclass
+class Scenario:
+    scenario_id: str
+    mode: str  # "offline" | "live"
+    persona: str  # 相对路径，如 src/eco-prof.md
+    skills: List[str]  # skill 文件路径列表
+    rubric: str  # rubric 文件路径
+    input_text: str  # ## Input 段内容
+    fixture: Optional[str] = None  # offline 模式的 fixture 名称
+    tags: List[str] = field(default_factory=list)
+    notes: str = ""
+
+
+@dataclass
+class RubricItem:
+    id: str
+    question: str
+
+
+@dataclass
+class Rubric:
+    rubric_id: str
+    items: List[RubricItem]
+
+
+def _split_frontmatter(text: str):
+    """将 Markdown 文本拆分为 (frontmatter_dict, body_str)。"""
+    text = text.strip()
+    if not text.startswith("---"):
+        return {}, text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}, text
+    fm_raw = text[3:end].strip()
+    body = text[end + 4 :].strip()
+    fm = yaml.safe_load(fm_raw) or {}
+    return fm, body
+
+
+def parse_scenario(path: str | Path) -> Scenario:
+    """解析 scenario Markdown 文件，返回 Scenario dataclass。"""
+    content = Path(path).read_text(encoding="utf-8")
+    fm, body = _split_frontmatter(content)
+
+    # 提取 ## Input 段
+    input_match = re.search(r"## Input\s*\n(.*?)(?=\n## |\Z)", body, re.DOTALL)
+    input_text = input_match.group(1).strip() if input_match else ""
+
+    # 提取 ## Notes 段
+    notes_match = re.search(r"## Notes\s*\n(.*?)(?=\n## |\Z)", body, re.DOTALL)
+    notes = notes_match.group(1).strip() if notes_match else ""
+
+    return Scenario(
+        scenario_id=fm.get("scenario_id", Path(path).stem),
+        mode=fm.get("mode", "offline"),
+        persona=fm.get("persona", "src/eco-prof.md"),
+        skills=fm.get("skills") or [],
+        rubric=fm.get("rubric", ""),
+        input_text=input_text,
+        fixture=fm.get("fixture"),
+        tags=fm.get("tags") or [],
+        notes=notes,
+    )
+
+
+def parse_rubric(path: str | Path) -> Rubric:
+    """解析 rubric Markdown 文件，返回 Rubric dataclass。"""
+    content = Path(path).read_text(encoding="utf-8")
+    fm, body = _split_frontmatter(content)
+
+    rubric_id = fm.get("rubric_id", Path(path).stem)
+
+    # 解析列表项：- id: xxx\n  question: ...
+    items: List[RubricItem] = []
+    item_pattern = re.compile(
+        r"-\s+id:\s*(\S+)\s*\n\s+question:\s*(.+?)(?=\n-\s+id:|\Z)",
+        re.DOTALL,
+    )
+    for m in item_pattern.finditer(body):
+        item_id = m.group(1).strip()
+        question = m.group(2).strip()
+        items.append(RubricItem(id=item_id, question=question))
+
+    return Rubric(rubric_id=rubric_id, items=items)

--- a/evals/harness/run.py
+++ b/evals/harness/run.py
@@ -1,0 +1,237 @@
+"""
+harness/run.py — Eval 入口（ADR-003 决策 3、7、9、14）
+
+用法：
+  python -m evals.harness.run --scenario evals/smoke/scenarios/hello.md
+  python -m evals.harness.run --scenario evals/micro/scenarios/basic_cn.md
+
+流程：
+  1. 解析 scenario
+  2. offline 模式复制 fixture DB
+  3. agent_builder.build(scenario) 生成临时 agent
+  4. subprocess 调 opencode run --agent <temp> --format json
+  5. 解析事件流 → conversation.md + events.jsonl
+  6. judge.score(conversation, rubric) 拿分
+  7. 生成 report.md
+  8. agent_builder.cleanup
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+
+from . import agent_builder, judge
+from .parser import parse_rubric, parse_scenario
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+_RESULTS_DIR = Path(__file__).parent.parent / "results"
+_FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+_LAB_DB_DIR = _REPO_ROOT / "lab" / "db"
+
+
+# ── DB 复制（offline 模式）────────────────────────────────────────────────────
+
+
+def _setup_fixture(fixture_name: str) -> None:
+    """将 evals/fixtures/<fixture_name>.db 复制到 lab/db/micro.db。"""
+    src = _FIXTURES_DIR / f"{fixture_name}.db"
+    dst = _LAB_DB_DIR / "micro.db"
+    if not src.exists():
+        raise FileNotFoundError(
+            f"Fixture not found: {src}\nRun: python -m evals.harness.seed_fixtures"
+        )
+    _LAB_DB_DIR.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(str(src), str(dst))
+    print(f"[harness] Fixture copied: {src} → {dst}")
+
+
+# ── 事件流解析（ADR-003 决策 9）──────────────────────────────────────────────
+
+
+def _parse_events(raw_output: str) -> tuple[str, List[Dict[str, Any]]]:
+    """
+    解析 opencode --format json 的事件流。
+    返回 (conversation_md, events_list)。
+    """
+    events: List[Dict[str, Any]] = []
+    conv_parts: List[str] = []
+
+    for line in raw_output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        events.append(event)
+
+        event_type = event.get("type", "")
+        if event_type == "text":
+            content = event.get("content", "")
+            if content:
+                conv_parts.append(f"**Assistant:** {content}")
+        elif event_type == "tool_call":
+            name = event.get("name", "tool")
+            params = json.dumps(event.get("input", {}), ensure_ascii=False)
+            conv_parts.append(f"**Tool ({name}):** `{params[:200]}`")
+
+    conversation_md = "\n\n".join(conv_parts) if conv_parts else raw_output
+    return conversation_md, events
+
+
+# ── 报告生成（ADR-003 决策 14）───────────────────────────────────────────────
+
+
+def _build_report(
+    scenario_id: str,
+    conversation_md: str,
+    scores: Dict[str, Any],
+    rubric_items: list,
+) -> str:
+    """生成 report.md，含 rubric 打分 + Human review checkbox。"""
+    lines = [
+        f"# Eval Report: {scenario_id}",
+        f"Generated: {datetime.now(timezone.utc).isoformat()}",
+        "",
+        "## Rubric Results",
+        "",
+    ]
+
+    if scores.get("_skipped"):
+        lines.append(f"> Judge skipped: {scores.get('_reason', 'unknown')}")
+        lines.append("")
+    elif scores.get("_parse_error"):
+        lines.append("> Judge response parse error.")
+        lines.append("")
+    else:
+        pass_count = sum(
+            1 for item in rubric_items if scores.get(item.id, {}).get("pass")
+        )
+        total = len(rubric_items)
+        lines.append(f"**Score: {pass_count}/{total}**")
+        lines.append("")
+        for item in rubric_items:
+            s = scores.get(item.id, {})
+            status = "✅" if s.get("pass") else "❌"
+            reason = s.get("reason", "")
+            quote = s.get("quote", "")
+            lines.append(f"### {status} {item.id}")
+            lines.append(f"**Q:** {item.question}")
+            if reason:
+                lines.append(f"**Reason:** {reason}")
+            if quote:
+                lines.append(f"**Quote:** _{quote}_")
+            lines.append("")
+
+    lines += [
+        "## Human Review",
+        "",
+    ]
+    for item in rubric_items:
+        lines.append(f"- [ ] Human review: **{item.id}** — {item.question}")
+    lines.append("")
+
+    lines += [
+        "## Conversation",
+        "",
+        conversation_md,
+    ]
+    return "\n".join(lines)
+
+
+# ── 主流程 ────────────────────────────────────────────────────────────────────
+
+
+def run(scenario_path: str) -> Path:
+    """运行单个 scenario，返回结果目录路径。"""
+    scenario = parse_scenario(scenario_path)
+    rubric = parse_rubric(str(_REPO_ROOT / scenario.rubric))
+
+    # ── 结果目录 ──
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out_dir = _RESULTS_DIR / ts / scenario.scenario_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # ── offline fixture 复制 ──
+    if scenario.mode == "offline" and scenario.fixture:
+        _setup_fixture(scenario.fixture)
+
+    # ── 生成临时 agent ──
+    agent_name = agent_builder.build(scenario)
+    print(f"[harness] Temp agent: {agent_name}")
+
+    # ── 调用 opencode ──
+    raw_output = ""
+    try:
+        cmd = [
+            "opencode",
+            "run",
+            "--agent",
+            agent_name,
+            "--format",
+            "json",
+            "--dangerously-skip-permissions",
+            scenario.input_text,
+        ]
+        print(f"[harness] Running: {' '.join(cmd[:5])} ...")
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(_REPO_ROOT),
+        )
+        raw_output = result.stdout + result.stderr
+    except FileNotFoundError:
+        raw_output = f"[harness] opencode not found; skipping agent execution.\nInput: {scenario.input_text}"
+
+    # ── 解析事件流 ──
+    conversation_md, events = _parse_events(raw_output)
+    if not conversation_md.strip():
+        conversation_md = f"[No parseable events]\n\nRaw output:\n{raw_output[:2000]}"
+
+    # ── 保存产出物 ──
+    (out_dir / "conversation.md").write_text(conversation_md, encoding="utf-8")
+    (out_dir / "events.jsonl").write_text(
+        "\n".join(json.dumps(e, ensure_ascii=False) for e in events),
+        encoding="utf-8",
+    )
+
+    # ── judge 打分 ──
+    scores = judge.score(conversation_md, rubric)
+    (out_dir / "scores.json").write_text(
+        json.dumps(scores, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    # ── report.md ──
+    report_md = _build_report(
+        scenario.scenario_id, conversation_md, scores, rubric.items
+    )
+    (out_dir / "report.md").write_text(report_md, encoding="utf-8")
+
+    print(f"[harness] Results saved: {out_dir}")
+
+    # ── 清理临时 agent ──
+    agent_builder.cleanup(scenario.scenario_id)
+
+    return out_dir
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run agent eval scenario")
+    parser.add_argument("--scenario", required=True, help="Path to scenario .md file")
+    args = parser.parse_args()
+    run(args.scenario)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evals/harness/seed_fixtures.py
+++ b/evals/harness/seed_fixtures.py
@@ -1,0 +1,65 @@
+"""
+harness/seed_fixtures.py — Fixture 种子脚本（ADR-003 决策 8）
+
+跑 fetch_financials.py 拉三只股票数据，
+然后复制 lab/db/micro.db 到 evals/fixtures/micro_seeded.db。
+
+运行方式：
+  python -m evals.harness.seed_fixtures
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+_FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+_SCRIPTS_DIR = _REPO_ROOT / "lab" / "scripts"
+
+STOCKS = [
+    ("000725.SZ", "CN"),
+    ("00700.HK", "HK"),
+    ("AAPL", "US"),
+]
+
+
+def seed() -> int:
+    """拉取三只股票数据并复制到 evals/fixtures/micro_seeded.db。"""
+    _FIXTURES_DIR.mkdir(parents=True, exist_ok=True)
+
+    print("=== Seeding fixtures ===")
+    for code, country in STOCKS:
+        print(f"Fetching {code} ({country})...")
+        r = subprocess.run(
+            [
+                sys.executable,
+                str(_SCRIPTS_DIR / "fetch_financials.py"),
+                "--code",
+                code,
+                "--country",
+                country,
+            ],
+            cwd=str(_REPO_ROOT),
+        )
+        if r.returncode != 0:
+            print(f"  ERROR: fetch_financials.py failed for {code}", file=sys.stderr)
+            return 1
+
+    # 复制 micro.db → fixtures/micro_seeded.db
+    src_db = _REPO_ROOT / "lab" / "db" / "micro.db"
+    dst_db = _FIXTURES_DIR / "micro_seeded.db"
+    if not src_db.exists():
+        print(f"ERROR: {src_db} not found", file=sys.stderr)
+        return 1
+
+    shutil.copy2(str(src_db), str(dst_db))
+    print(f"Fixture saved: {dst_db}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(seed())

--- a/evals/smoke/rubrics/hello.md
+++ b/evals/smoke/rubrics/hello.md
@@ -1,0 +1,11 @@
+---
+rubric_id: smoke_hello
+---
+
+# Smoke Rubric
+
+- id: mentions_investment
+  question: 回答是否提到"投资"或"估值"相关概念？
+
+- id: mentions_three_engines
+  question: 回答是否提到三引擎架构（宏观/微观/元反思之一）？

--- a/evals/smoke/scenarios/hello.md
+++ b/evals/smoke/scenarios/hello.md
@@ -1,0 +1,15 @@
+---
+scenario_id: smoke_hello
+mode: offline
+persona: src/eco-prof.md
+skills: []
+rubric: evals/smoke/rubrics/hello.md
+tags: [smoke, hello-world]
+---
+
+## Input
+你好，介绍一下你自己。
+
+## Notes
+Smoke test：验证 harness 骨架可跑通（不依赖任何引擎数据）。
+评审 agent 自我介绍是否提到投资/估值相关概念以及三引擎架构。


### PR DESCRIPTION
## Summary

- 搭建 `evals/` 子系统，按 ADR-003 实现 agent eval harness 骨架
- `harness/parser.py`：Scenario/Rubric Markdown 解析
- `harness/agent_builder.py`：动态生成 opencode agent，跑完清理
- `harness/judge.py`：one-shot LLM judge（DeepSeek），JSON schema 校验
- `harness/run.py`：主流程（parse→fixture→agent→events→judge→report）
- `harness/seed_fixtures.py`：fixture 种子脚本
- Smoke scenario + rubric（自测 harness）
- `evals/README.md`、`evals/benchmark-log.md`

## 验收自检

```
test -d evals/harness && test -f evals/config.yaml && test -f evals/README.md  ✅
python -m evals.harness.run --scenario evals/smoke/scenarios/hello.md           ✅ 运行成功
grep -c "Human review" evals/results/*/smoke_hello/report.md                    ✅ 2
ls .opencode/agent/eval-*.md 2>/dev/null | wc -l                                ✅ 0（已清理）
python -m pytest tests/ -q                                                       ✅ 199 passed（无回退）
DEEPSEEK_API_KEY 未设置 → judge 跳过，report 仍生成                              ✅
```

Closes #35